### PR TITLE
Removed Unused 'ResultIncDir' Variable

### DIFF
--- a/make/post/rules.mak
+++ b/make/post/rules.mak
@@ -689,7 +689,7 @@ $(HeaderTargets):
 local-all: $(TARGETS) $(DEPENDS) $(HEADERS)
 	$(Quiet)true
 
-local-prepare: $(BuildDirectory) $(ResultDirectory) $(ResultIncDir) $(PrepareTargets) $(HEADERS)
+local-prepare: $(BuildDirectory) $(ResultDirectory) $(PrepareTargets) $(HEADERS)
 	$(Quiet)true
 
 $(foreach target,$(PrepareTargets),$(eval $(call DEPEND_template,$(target))))


### PR DESCRIPTION
This removes the unused `ResultIncDir` variable.