### PR TITLE
Added Two Macros for Copying and Enabling User Execute Permission on a File

### DIFF
--- a/make/host/tools/tools.mak
+++ b/make/host/tools/tools.mak
@@ -131,6 +131,31 @@ $(Echo) "Moving \"$(call GenerateBuildRootEllipsedPath,$@)\""
 $(Verbose)mv -f "$(<)" "$(@)"
 endef
 
+# copy-and-enable-user-executable <source> <destination>
+#
+# Common macro to copy the specified regular file and enable user
+# execute permission on the destination. This is most commonly used
+# for scripts (for example, bash, perl, python, etc.).
+
+define copy-and-enable-user-executable
+$(Echo) "Copying and adding user execute permissions to \"$(call GenerateBuildRootEllipsedPath,$(2))\""
+$(Verbose)$(RM) $(RMFLAGS) "$(2)" "$(2)-t"
+$(Verbose)cp "$(1)" "$(2)-t"
+$(Verbose)chmod +x "$(2)-t"
+$(Verbose)mv "$(2)-t" "$(2)"
+endef # copy-and-enable-user-executable
+
+# copy-and-enable-user-executable-result
+#
+# Common macro to copy the specified regular file from a target
+# dependency and enable user execute permission on the destination as
+# the target goal. This is most commonly used for scripts (for
+# example, bash, perl, python, etc.).
+
+define copy-and-enable-user-executable-result
+$(call copy-and-enable-user-executable,$(<),$(@))
+endef # copy-and-enable-user-executable-result
+
 # Common macro used in target commands for installing a file as the
 # target goal from the target dependency. Any missing parent
 # directories in the target result are created, differing from


### PR DESCRIPTION
This adds the `copy-and-enable-user-executable` and `copy-and-enable-user-executable-result` macros.

These copy a regular file and enable user execute permissions on the destination. These are most commonly used for scripts (for example, bash, perl, python, etc.).

The `-result` variant works against a target dependency (`$(<)`) as the source and its goal (`$(@)`) as the destination whereas the "bare" variant works against an explicit source and destination.