### PR TITLE
Reference 'grep' and 'sed' through Variables and Invoke with a 'FLAGS' Variable

### DIFF
--- a/make/host/tools/perl.mak
+++ b/make/host/tools/perl.mak
@@ -20,7 +20,7 @@
 #
 
 ifndef PerlVersion
-export PerlVersion := $(shell perl -V:version | $(SED) -n -e "s/^version='\(.\{1,\}\)';$$/\1/gp")
+export PerlVersion := $(shell perl -V:version | $(SED) $(SEDFLAGS) -n -e "s/^version='\(.\{1,\}\)';$$/\1/gp")
 endif
 
 ifndef PerlSiteDir

--- a/make/host/tools/tools.mak
+++ b/make/host/tools/tools.mak
@@ -25,6 +25,9 @@
 # locations (e.g. /bin, /usr/bin, /sbin, and /usr/sbin).
 #
 
+GREP                         = grep
+GREPFLAGS                    =
+
 INSTALL                      = /usr/bin/install
 INSTALLFLAGS                 = -C
 

--- a/make/post/rules.mak
+++ b/make/post/rules.mak
@@ -988,7 +988,7 @@ ifndef NoCheckToolVersions
 
 define check-tool-version
 	$(Echo) -n "Checking $(ToolDescription) version..."
-	$(Verbose)version=`$(ToolPath) $(ToolVersionArgs) 2>&1 | $(SED) -n -e $(ToolSedArgs)` ; \
+	$(Verbose)version=`$(ToolPath) $(ToolVersionArgs) 2>&1 | $(SED) $(SEDFLAGS) -n -e $(ToolSedArgs)` ; \
 	echo $$version; \
 	echo $$version | grep -q $(ToolGrepArgs); \
 	if [ $$? -ne 0 ]; then \

--- a/make/post/rules.mak
+++ b/make/post/rules.mak
@@ -990,7 +990,7 @@ define check-tool-version
 	$(Echo) -n "Checking $(ToolDescription) version..."
 	$(Verbose)version=`$(ToolPath) $(ToolVersionArgs) 2>&1 | $(SED) $(SEDFLAGS) -n -e $(ToolSedArgs)` ; \
 	echo $$version; \
-	echo $$version | grep -q $(ToolGrepArgs); \
+	echo $$version | $(GREP) $(GREPFLAGS) -q $(ToolGrepArgs); \
 	if [ $$? -ne 0 ]; then \
 		echo "Unexpected version for \"$(ToolPath)\"!"; \
 		false; \

--- a/make/pre/macros/paths.mak
+++ b/make/pre/macros/paths.mak
@@ -53,14 +53,14 @@ IsPath				= $(if $(findstring $(Slash),$(1)),$(1),)
 # If the path is relative (i.e. does not contain a leading directory
 # delimiter), the path is returned.
 
-IsRelativePath			= $(shell echo $(1) | $(SED) -ne '/^[^/]/p')
+IsRelativePath			= $(shell echo $(1) | $(SED) $(SEDFLAGS) -ne '/^[^/]/p')
 
 # IsAbsolutePath <path>
 #
 # If the path is absolute (i.e. contains a leading directory
 # delimiter), the path is returned.
 
-IsAbsolutePath			= $(shell echo $(1) | $(SED) -ne '/^[/]/p')
+IsAbsolutePath			= $(shell echo $(1) | $(SED) $(SEDFLAGS) -ne '/^[/]/p')
 
 # FilterRelativePaths <paths>
 #
@@ -79,7 +79,7 @@ FilterAbsolutePaths		= $(foreach path,$(1),$(call IsAbsolutePath,$(path)))
 # Generates the relative path of the specified directory to the base
 # directory.
 
-GenerateRelativeBasePath	= $(shell echo $(1) | $(SED) -e s,$(call Slashify,$(2)),,g -e 's/[^\/]\{1,\}\(\/*\)/..\1/g')
+GenerateRelativeBasePath	= $(shell echo $(1) | $(SED) $(SEDFLAGS) -e s,$(call Slashify,$(2)),,g -e 's/[^\/]\{1,\}\(\/*\)/..\1/g')
 
 # RemovePath <path> <base>
 #

--- a/make/pre/macros/tps.mak
+++ b/make/pre/macros/tps.mak
@@ -53,7 +53,7 @@ _PackageHasThirdPartyReadMePath_N := $(_PackageHasThirdPartyReadMePath_)
 _PackageHasThirdPartyReadMePath_Y  = $(_PackageHasThirdPartyReadMePath)
 
 define _package-extract-third_party-field-from-path
-$(shell sed -n -e 's/$(1):[[:space:]]*//gp' "$(2)")
+$(shell $(SED) $(SEDFLAGS) -n -e 's/$(1):[[:space:]]*//gp' "$(2)")
 endef # _package-extract-third_party-field-from-path
 
 define _package-extract-third_party-field


### PR DESCRIPTION
Ensure that the invocation of `grep` and `sed` always happens through the respective `$(GREP)` and `$(SED)` variables and is in conjunction with their respective `$(GREPFLAGS)` and `$(SEDFLAGS)` variables.

This sets the stage for improved portability between macOS and Linux with BSD and Linux grep/sed.