### PR TITLE
Add GitHub Continuous Integration Support for Linux against the 'bash' Shell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+#
+#    Copyright (c) 2023 Nuovation System Designs, LLC. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the GitHub Actions hosted, distributed continuous 
+#      integration configuration file for the Nuovations Build (make)
+#      build system.
+#
+
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+
+  linux:
+    runs-on: ubuntu-latest
+    name: "Linux ${{matrix.compiler['name']}}"
+    strategy:
+      matrix:
+        compiler:
+          - { name: GCC,        c: gcc,   cxx: g++ }
+    env:
+      CC: ${{matrix.compiler['c']}}
+      CXX: ${{matrix.compiler['cxx']}}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bash csh dash ksh tcsh zsh
+    - name: Test
+      run: |
+        make check
+    - name: Distribution
+      run: |
+        make -j dist

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ PACKAGE              := nuovations-build-make
 TARGET               := $(PACKAGE)
 
 #
+# Make Jobs
+#
+
+JOBS                 ?= $(shell getconf _NPROCESSORS_ONLN)
+
+#
 # Tools
 #
 CAT                  ?= cat
@@ -360,12 +366,73 @@ $(dist_txz_TARGETS): stage
 # Produce an architecture-independent distribution of the
 # nlbuild-autotools core.
 #
+
 dist: $(DIST_TARGETS) $(builddir)/.local-version
 	$(call remove-dir,$(distdir))
 
 dist-tgz: $(dist_tgz_TARGETS)
 
 dist-txz: $(dist_txz_TARGETS)
+
+check-clean-examples:
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples clean-examples-debug
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples clean-examples-development
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples clean-examples-release
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples clean-debug
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples clean-development
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples clean-release
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples clean-examples
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples clean
+
+check-distclean-examples: check-clean-examples
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples distclean-examples-debug
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples distclean-examples-development
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples distclean-examples-release
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples distclean-debug
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples distclean-development
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples distclean-release
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples distclean-examples
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples distclean
+
+check-examples: check-clean-examples check-distclean-examples
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples examples-debug
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples examples-development
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples examples-release
+	+$(V_AT)$(MAKE) -j $(JOBS) -C examples examples
+	+$(V_AT)$(MAKE) check-clean-examples
+	+$(V_AT)$(MAKE) check-distclean-examples
+
+#
+# check-examples-with-shell <shell name> <shell source command>
+#
+# Check the package by running the examples against a particular shell.
+# to be updated.
+#
+# This performs the following steps:
+#
+#   1. Displays progress about the target being made, the shell being
+#      invoked, and the make being performed for 'examples'.
+#   2. Invokes the specified shell with the '-c' option, changing
+#      directory to 'examples', sourcing the appropriate shell-specific
+#      build environment setup script, and then re-invoking this makefile
+#      from that shell with the 'check-examples' target.
+#
+define check-examples-with-shell
+$(V_MAKE_TARGET)
+$(V_PROGRESS) "$(shell echo $(1) | tr '[[:lower:]]' '[[:upper:]]')" "$(shell which $(1))"
+$(V_PROGRESS) "MAKE" "examples"
+$(V_AT)$(1) -c 'cd examples && $(2) build/scripts/environment/setup.$(1) && $(MAKE) -C $(CURDIR) check-examples'
+endef # check-examples-with-shell
+
+check-examples-bash:
+	$(call check-examples-with-shell,bash,.)
+
+check: check-examples-bash
+
+distcheck:
+	$(V_MAKE_TARGET)
+	+$(V_AT)$(MAKE) check
+	+$(V_AT)$(MAKE) -j $(JOBS) dist
 
 clean-local:
 	$(V_PROGRESS) "CLEAN" "."

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Build Status][nuovations-build-make-github-action-svg]][nuovations-build-make-github-action]
+[nuovations-build-make-github]: https://github.com/nuovations/nuovations-build-make
+[nuovations-build-make-github-action]: https://github.com/nuovations/nuovations-build-make/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush
+[nuovations-build-make-github-action-svg]: https://github.com/nuovations/nuovations-build-make/actions/workflows/build.yml/badge.svg?branch=main&event=push
+
 Nuovations Build (Make)
 =======================
 


### PR DESCRIPTION
This partially addresses #10 by adding GitHub action continuous integration (CI) support for Linux using the `bash` shell.