### PR TITLE
Enhance CI by Adding 'dash' to the List of Shells to Run 'make check' Against

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,10 +427,13 @@ endef # check-examples-with-shell
 check-examples-bash:
 	$(call check-examples-with-shell,bash,.)
 
+check-examples-dash:
+	$(call check-examples-with-shell,dash,.)
+
 check-examples-zsh:
 	$(call check-examples-with-shell,zsh,.)
 
-check: check-examples-bash check-examples-zsh
+check: check-examples-bash check-examples-dash check-examples-zsh
 
 distcheck:
 	$(V_MAKE_TARGET)


### PR DESCRIPTION
This partially addresses #10 and enhances continuous integration (CI) by adding `dash` to the list of shells to run `make check` against.