### PR TITLE
Enhance CI by Adding 'sh' to the List of Shells to Run 'make check' Against

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,13 +433,16 @@ check-examples-csh:
 check-examples-dash:
 	$(call check-examples-with-shell,dash,.)
 
+check-examples-sh:
+	$(call check-examples-with-shell,sh,.)
+
 check-examples-tcsh:
 	$(call check-examples-with-shell,tcsh,source)
 
 check-examples-zsh:
 	$(call check-examples-with-shell,zsh,.)
 
-check: check-examples-bash check-examples-csh check-examples-dash check-examples-tcsh check-examples-zsh
+check: check-examples-bash check-examples-csh check-examples-dash check-examples-sh check-examples-tcsh check-examples-zsh
 
 distcheck:
 	$(V_MAKE_TARGET)


### PR DESCRIPTION
This partially addresses #10 and enhances continuous integration (CI) by adding `sh` to the list of shells to run `make check` against.