### PR TITLE
Split 'create-directory' into Two Macros

### DIFF
--- a/make/host/tools/tools.mak
+++ b/make/host/tools/tools.mak
@@ -67,12 +67,23 @@ SEDFLAGS                     =
 MKGENERATION                := $(BuildRoot)/third_party/nuovations-build-make/repo/scripts/mkgeneration
 MKGENERATIONFLAGS            =
 
-# Common macro used in target commands for creating a directory as
-# the target goal.
+# create-directory <path name>
+#
+# Common macro used for creating a directory from the specified path
+# name.
 
 define create-directory
-$(Echo) "Creating \"$(call GenerateBuildRootEllipsedPath,$@)\""
-$(Verbose)$(MKDIR) $(MKDIRFLAGS) $@
+$(Echo) "Creating \"$(call GenerateBuildRootEllipsedPath,$(1))\""
+$(Verbose)$(MKDIR) $(MKDIRFLAGS) "$(1)"
+endef
+
+# create-directory-result
+#
+# Common macro used in target commands for creating a directory as
+# the target built-in make variable.
+
+define create-directory-result
+$(call create-directory,$(@))
 endef
 
 # Common macro used in target distclean commands for removing all

--- a/make/post/rules.mak
+++ b/make/post/rules.mak
@@ -1033,7 +1033,7 @@ do-check-make:
 # might all effectively be the same directory.
 
 $(DependDirectory) $(BuildDirectory) $(ResultDirectory):
-	$(create-directory)
+	$(create-directory-result)
 
 # Since the timestamp on directories change every time a file is
 # added, specify the parent directory of these paths as an order-only

--- a/make/post/rules/tps.mak
+++ b/make/post/rules/tps.mak
@@ -57,7 +57,7 @@ ifneq ($(PackageBuildMode),$(_PackageBuildModeDefault))
 # Create, if necessary, the snapshot archive directory.
 
 $(PackageSnapshotDir):
-	$(create-directory)
+	$(create-directory-result)
 
 # Snapshot a build from the temporary installation area.
 


### PR DESCRIPTION
This splits the `create-directory` macro into both `create-directory` and `create-directory-result`.

This expands the existing pattern of _<*>_ and _<*>-result_ macros in which the former operates on an explicit argument(s) and the latter operates on the built-in make target result (`$(@)`) and target dependency (`$(<)`) variables.