### PR TITLE
Split 'install-result' into Two

### DIFF
--- a/make/host/tools/darwin.mak
+++ b/make/host/tools/darwin.mak
@@ -23,12 +23,14 @@
 LNDIR		= lndir -silent
 SIZE		= /usr/bin/stat -f "%z"
 
-# Host-dependent implementation of the macro used in target commands
-# for installing a file as the target goal from the target
-# dependency. Any missing parent directories in the target result are
-# created.
+# host-install <source path> <destination path>
+#
+# Host-dependent implementation of the macro for installing a
+# destination file from a source file.
+#
+# Any missing parent directories in the destination path are created.
 
-define host-install-result
-$(Verbose)$(MKDIR) $(MKDIRFLAGS) "$(@D)"
-$(Verbose)$(INSTALL) $(INSTALLFLAGS) "$(<)" "$(@)"
+define host-install
+$(Verbose)$(MKDIR) $(MKDIRFLAGS) "$(dir $(1))"
+$(Verbose)$(INSTALL) $(INSTALLFLAGS) "$(1)" "$(2)"
 endef

--- a/make/host/tools/linux.mak
+++ b/make/host/tools/linux.mak
@@ -23,11 +23,13 @@
 LNDIR		= cp -rs
 SIZE		= /usr/bin/stat -c "%s"
 
-# Host-dependent implementation of the macro used in target commands
-# for installing a file as the target goal from the target
-# dependency. Any missing parent directories in the target result are
-# created.
+# host-install <source path> <destination path>
+#
+# Host-dependent implementation of the macro for installing a
+# destination file from a source file.
+#
+# Any missing parent directories in the destination path are created.
 
-define host-install-result
-$(Verbose)$(INSTALL) $(INSTALLFLAGS) -D "$(<)" "$(@)"
+define host-install
+$(Verbose)$(INSTALL) $(INSTALLFLAGS) -D "$(1)" "$(2)"
 endef

--- a/make/host/tools/tools.mak
+++ b/make/host/tools/tools.mak
@@ -170,17 +170,34 @@ define copy-and-enable-user-executable-result
 $(call copy-and-enable-user-executable,$(<),$(@))
 endef # copy-and-enable-user-executable-result
 
+# install <source path> <destination path>
+#
+# Common macro for installing a destination file from a source file.
+#
+# Any missing parent directories in the destination path are created.
+#
+# This is conducted in a host-dependent fashion.
+
+define install
+$(Echo) "Installing \"$(call GenerateBuildRootEllipsedPath,$(2))\""
+$(call host-install,$(1),$(2))
+endef # install
+
+# install-result
+#
 # Common macro used in target commands for installing a file as the
-# target goal from the target dependency. Any missing parent
-# directories in the target result are created, differing from
-# copy-result above in which parent directories MUST exist.
+# target goal from the target dependency, using the corresponding
+# built-in make variables, $(@) and $(<), respectively.
+#
+# Any missing parent directories in the target result are created,
+# differing from copy-result above in which parent directories MUST
+# exist.
 #
 # This is conducted in a host-dependent fashion.
 
 define install-result
-$(Echo) "Installing \"$(call GenerateBuildRootEllipsedPath,$@)\""
-$(host-install-result)
-endef
+$(call install,$(<),$(@))
+endef # install-result
 
 # expand-archive <source archive> <destination directory>
 #


### PR DESCRIPTION
Split `install-result` into both `install` and `install-result`.

This expands the existing pattern of _<*>_ and _<*>-result_ macros in which the former operates on an explicit argument(s) and the latter operates on the built-in make target result (`$(@)`) and target dependency (`$(<)`) variables.