### PR TITLE
Add Tool-specific Optimizer Flag Variables / Add Debug Optimizer Level Variable

### DIFF
--- a/examples/build/make/products/examples.mak
+++ b/examples/build/make/products/examples.mak
@@ -68,7 +68,11 @@ CPPOPTFLAGS             += $(MACHFLAGS)
 CCLANGSTDFLAGS          += $(call ToolAssertLanguageStandardFlag,$(LangStandardC2011))
 CXXLANGSTDFLAGS         += $(call ToolAssertLanguageStandardFlag,$(LangStandardCxx2014))
 
+CCOPTIMIZER              = $(OPTIMIZER)
+
 CCOPTFLAGS              += $(CCLANGSTDFLAGS) $(CCLANGFLAGS) $(LANGFLAGS)
+
+CXXOPTIMIZER             = $(OPTIMIZER)
 
 CXXOPTFLAGS             += $(CXXLANGSTDFLAGS) $(CXXLANGFLAGS) $(LANGFLAGS)
 

--- a/make/target/tools/apple/clang/tools.mak
+++ b/make/target/tools/apple/clang/tools.mak
@@ -65,6 +65,7 @@ ProfileFlag                        = -pg
 
 # Optimizer variables
 
+OptimizeDebug                      = -Og
 OptimizeNone                       = -O0
 OptimizeLeast                      = -O1
 OptimizeLess                       = -O1

--- a/make/target/tools/apple/clang/tools.mak
+++ b/make/target/tools/apple/clang/tools.mak
@@ -156,7 +156,7 @@ ASName                             = $(call MakeToolName,$(AS))
 ASInputFlag                        = $(ClangInputFlag)
 ASOutputFlag                       = $(ClangOutputFlag)
 
-ASFLAGS                           += $(ASOPTFLAGS) $(ASWARNINGS) $(ClangNoLinkFlag)
+ASFLAGS                           += $(ASOPTIMIZER) $(ASOPTFLAGS) $(ASWARNINGS) $(ClangNoLinkFlag)
 
 # The C preprocessor
 
@@ -186,7 +186,7 @@ CCOutputFlag                       = $(ClangOutputFlag)
 CCPICFlag                          = $(ClangPICFlag)
 CCCoverageFlag                     = $(ClangCoverageFlag)
 
-CCFLAGS                            = $(CCOPTFLAGS) $(CCWARNINGS)
+CCFLAGS                            = $(CCOPTIMIZER) $(CCOPTFLAGS) $(CCWARNINGS)
 
 # The C++ compiler
 
@@ -199,7 +199,7 @@ CXXOutputFlag                      = $(ClangOutputFlag)
 CXXPICFlag                         = $(ClangPICFlag)
 CXXCoverageFlag                    = $(ClangCoverageFlag)
 
-CXXFLAGS                           = $(CXXOPTFLAGS) $(CXXWARNINGS)
+CXXFLAGS                           = $(CXXOPTIMIZER) $(CXXOPTFLAGS) $(CXXWARNINGS)
 
 # The Objective C compiler flag
 

--- a/make/target/tools/gnu/gcc/tools.mak
+++ b/make/target/tools/gnu/gcc/tools.mak
@@ -74,6 +74,7 @@ ProfileFlag                     = -pg
 
 # Optimizer variables
 
+OptimizeDebug                   = -Og
 OptimizeNone                    = -O0
 OptimizeLeast                   = -O1
 OptimizeLess                    = -O1

--- a/make/target/tools/gnu/gcc/tools.mak
+++ b/make/target/tools/gnu/gcc/tools.mak
@@ -165,7 +165,7 @@ ASName                          = $(call MakeToolName,$(AS))
 ASInputFlag                     = $(GccInputFlag)
 ASOutputFlag                    = $(GccOutputFlag)
 
-ASFLAGS                         += $(ASOPTFLAGS) $(ASWARNINGS) $(GccNoLinkFlag)
+ASFLAGS                         += $(ASOPTIMIZER) $(ASOPTFLAGS) $(ASWARNINGS) $(GccNoLinkFlag)
 
 # The C preprocessor
 
@@ -195,7 +195,7 @@ CCOutputFlag                    = $(GccOutputFlag)
 CCPICFlag                       = $(GccPICFlag)
 CCCoverageFlag                  = $(GccCoverageFlag)
 
-CCFLAGS                         = $(CCOPTFLAGS) $(CCWARNINGS)
+CCFLAGS                         = $(CCOPTIMIZER) $(CCOPTFLAGS) $(CCWARNINGS)
 
 # The C++ compiler
 
@@ -208,7 +208,7 @@ CXXOutputFlag                   = $(GccOutputFlag)
 CXXPICFlag                      = $(GccPICFlag)
 CXXCoverageFlag                 = $(GccCoverageFlag)
 
-CXXFLAGS                        = $(CXXOPTFLAGS) $(CXXWARNINGS)
+CXXFLAGS                        = $(CXXOPTIMZER) $(CXXOPTFLAGS) $(CXXWARNINGS)
 
 # The Objective C compiler flag
 

--- a/templates/product.mak
+++ b/templates/product.mak
@@ -40,7 +40,11 @@ CPPOPTFLAGS             += $(MACHFLAGS)
 CCLANGSTDFLAGS          += $(call ToolAssertLanguageStandardFlag,$(LangStandardC2011))
 CXXLANGSTDFLAGS         += $(call ToolAssertLanguageStandardFlag,$(LangStandardCxx2014))
 
+CCOPTIMIZER              = $(OPTIMIZER)
+
 CCOPTFLAGS              += $(CCLANGSTDFLAGS) $(CCLANGFLAGS) $(LANGFLAGS)
+
+CXXOPTIMIZER             = $(OPTIMIZER)
 
 CXXOPTFLAGS             += $(CXXLANGSTDFLAGS) $(CXXLANGFLAGS) $(LANGFLAGS)
 


### PR DESCRIPTION
This adds three new tool-specific optimizer variables:

* `ASOPTIMIZER`
    * For the assembler.
* `CCOPTIMIER`
    * For the C compiler.
* `CXXOPTIMIZER`
    * For the C++ compiler.

and adds the new `OptimizeDebug` optimizer level flag.