### PR TITLE
scripts: Fix 'printenv' 'BuildRoot' and 'Home' Environment Variable Substitution

### DIFF
--- a/scripts/printenv
+++ b/scripts/printenv
@@ -39,7 +39,11 @@ FilterOut()
     path="$(eval echo \${${1}})"
     variable="\${${1}}"
 
-    sed -r -e 's,'"${path}"','"${variable}"',g'
+    if [ -n "${path}" ]; then
+        sed -r -e 's,'"${path}"','"${variable}"',g'
+    else
+        cat
+    fi
 }
 
 # SetIfPresent <path>

--- a/scripts/printenv
+++ b/scripts/printenv
@@ -36,7 +36,10 @@
 
 FilterOut()
 {
-    sed -e "s,${1},\${${1}},g"
+    path="$(eval echo \${${1}})"
+    variable="\${${1}}"
+
+    sed -r -e 's,'"${path}"','"${variable}"',g'
 }
 
 # SetIfPresent <path>

--- a/scripts/printenv
+++ b/scripts/printenv
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-#    Copyright (c) 2008-2023 Nuovation System Design, LLC. All Rights Reserved.
+#    Copyright (c) 2008-2024 Nuovation System Design, LLC. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This addresses #23 by modifying the `printenv` script in _scripts/printenv_  such that it correctly substitutes the `BuildRoot` and `HOME` environment variables as follows:

```
================================================================================
Project build environment set to:
  Build Root            = ${HOME}/src/git/github.com/nuovations/nuovations-build-make/examples
  Make Flags            = --no-print-directory -r -R -I ${BuildRoot}/third_party/nuovations-build-make/repo/make -I ${BuildRoot}/build/make
  Global Environment    = <None>
  Local Environment     = <None>
================================================================================
```

rather than:

```
================================================================================
Project build environment set to:
  Build Root            = /home/gerickson/src/git/github.com/nuovations/nuovations-build-make/examples
  Make Flags            = --no-print-directory -r -R -I /home/gerickson/src/git/github.com/nuovations/nuovations-build-make/examples/third_party/nuovations-build-make/repo/make -I /home/gerickson/src/git/github.com/nuovations/nuovations-build-make/examples/build/make
  Global Environment    = <None>
  Local Environment     = <None>
================================================================================
```

in addition, if neither are set, it no longer errors out with:

```
sed: -e expression #1, char 0: no previous regular expression
```