### PR TITLE
Include 'HeaderTargets' in 'ResultPaths'.

### DIFF
--- a/make/post/rules.mak
+++ b/make/post/rules.mak
@@ -961,7 +961,7 @@ DependPaths             = $(BaseDependPaths) $(PatchedDependPaths)
 BuildPaths              += $(OBJECTS)
 BuildPaths		+= $(GENERATIONS)
 
-ResultPaths             += $(ArchiveTargets) $(LibraryTargets) $(ProgramTargets) $(ImageTargets)
+ResultPaths             += $(HeaderTargets) $(ArchiveTargets) $(LibraryTargets) $(ProgramTargets) $(ImageTargets)
 
 # These are what post.mak will rely upon to include in all makefiles
 # that include post.mak.


### PR DESCRIPTION
This ensures that headers are removed, along with archives, libraries, programs, and images for the 'clean' and 'distclean' targets.