### PR TITLE
target/tools/gcc: Fix a typo of 'CXXOPTIMIZER'.

### DIFF
--- a/make/target/tools/gnu/gcc/tools.mak
+++ b/make/target/tools/gnu/gcc/tools.mak
@@ -208,7 +208,7 @@ CXXOutputFlag                   = $(GccOutputFlag)
 CXXPICFlag                      = $(GccPICFlag)
 CXXCoverageFlag                 = $(GccCoverageFlag)
 
-CXXFLAGS                        = $(CXXOPTIMZER) $(CXXOPTFLAGS) $(CXXWARNINGS)
+CXXFLAGS                        = $(CXXOPTIMIZER) $(CXXOPTFLAGS) $(CXXWARNINGS)
 
 # The Objective C compiler flag
 


### PR DESCRIPTION
This fixes a typo of `CXXOPTIMIZER` for GCC.