### PR TITLE
Fix False Silent-mode Detection on GNU Make 4.4+

### DIFF
--- a/make/pre/macros/verbosity.mak
+++ b/make/pre/macros/verbosity.mak
@@ -41,7 +41,7 @@ BuildVerbose_Y        = $(call IsYes,$(BuildVerbose))
 
 Quiet                := @
 
-ifneq ($(findstring s,$(MAKEFLAGS)),)
+ifneq ($(findstring s,$(firstword -$(MAKEFLAGS))),)
 Echo                  = $(Quiet)true
 Verbose               = $(Quiet)
 else


### PR DESCRIPTION
This fully addresses and closes #29, fixing false silent-mode detection on GNU `make` 4.4+.

GNU Make 4.4 changed the encoding of `MAKEFLAGS` in a backward-incompatible way. Per the 4.4 _NEWS_:

> Previously only simple (one-letter) options were added to the
> `MAKEFLAGS` variable that was visible while parsing makefiles.
> Now, all options are available in `MAKEFLAGS`.

As a result, `MAKEFLAGS` now routinely contains long options such as `--jobserver-auth=fifo:/tmp/GMfifo<pid>`, `--no-print-directory`, and `--output-sync=...`, several of which contain the letter `s`. The existing `$(findstring s,$(MAKEFLAGS))` test for the -s short option therefore matches whenever any such long option is present, which is the default on 4.4+, forcing the build into silent mode unconditionally and ignoring `BuildVerbose=Yes`.

Restrict the test to the leading short-options word by passing `$(MAKEFLAGS)` through `$(firstword -$(MAKEFLAGS))`. The leading dash ensures firstword always returns the short-options chunk: 4.4+ leaves a leading space in `MAKEFLAGS` when no short options are set, so an unprefixed firstword can otherwise return the first long option.

This idiom is the upstream-recommended pattern for testing short options post-4.4 (see the GNU Make 4.4 NEWS file and the Git project's _shared.mak_ adoption of the same construct), and is backward-compatible with 4.3 and earlier.