### PR TITLE
Split Shared/static Object Multi-target Pattern Rules

### DIFF
--- a/make/post/rules.mak
+++ b/make/post/rules.mak
@@ -473,6 +473,44 @@ $(call GenerateBuildPaths,%$(StaticObjectSuffix)): %.s79 | $(DependDirectory) $(
 # Shared and Static Object Implicit Pattern Rules
 #
 
+# OBJECT_RULE_template <source-suffix> <recipe-name>
+#
+# Instantiates separate single-target pattern rules for the shared
+# and static object outputs, both driven by the same recipe. The
+# recipe produces whichever output $@ names; the per-suffix CCFLAGS
+# / CXXFLAGS overrides (PIC vs non-PIC) select correctly because
+# they're already keyed on SharedObjectSuffix vs StaticObjectSuffix.
+#
+# make-4.3 introduced grouped multi-target pattern rules; make-4.4
+# introduced warnings the the deprecation of non-grouped multi-target
+# pattern rules; and some version of make in the future will deprecate
+# them entirely. This is the post-make-4.4 form. Multi-target pattern
+# rules (%$(SharedObjectSuffix) %$(StaticObjectSuffix) on a single
+# rule) now imply grouped-target semantics, requiring the recipe to
+# produce all peers; these recipes produce only one output per
+# invocation.
+
+define OBJECT_RULE_template
+$$(call GenerateBuildPaths,%$$(SharedObjectSuffix)): $(1) | $$(DependDirectory) $$(BuildDirectory)
+	$$($(2))
+
+$$(call GenerateBuildPaths,%$$(StaticObjectSuffix)): $(1) | $$(DependDirectory) $$(BuildDirectory)
+	$$($(2))
+endef # OBJECT_RULE_template
+
+# AUTOGEN_OBJECT_RULE_template <source-suffix> <recipe-name>
+#
+# As OBJECT_RULE_template, but for auto-generated sources whose
+# inputs already live in the build directory.
+
+define AUTOGEN_OBJECT_RULE_template
+$$(call GenerateBuildPaths,%$$(SharedObjectSuffix)): $$(call GenerateBuildPaths,$(1)) | $$(DependDirectory) $$(BuildDirectory)
+	$$($(2))
+
+$$(call GenerateBuildPaths,%$$(StaticObjectSuffix)): $$(call GenerateBuildPaths,$(1)) | $$(DependDirectory) $$(BuildDirectory)
+	$$($(2))
+endef # AUTOGEN_OBJECT_RULE_template
+
 # Unconditionally add the shared object flag for shared objects.
 
 $(call GenerateBuildPaths,%$(SharedObjectSuffix)): CCFLAGS  += $(CCPICFlag)
@@ -495,127 +533,49 @@ $(call GenerateBuildPaths,%$(StaticObjectSuffix)): CXXFLAGS += $(CXXFLAGS_Enable
 
 # Handle input source files in the makefile directory with output in the build directory.
 
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.c.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c-or-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.m.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-objective-c-or-objective-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.cc.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.cp.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.cxx.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.cpp.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.CPP.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.c++.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.C.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.mm.i | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-objective-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.c | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c-or-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.m | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-objective-c-or-objective-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.cc | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.cp | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.cxx | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.cpp | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.CPP | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.c++ | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.C | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): %.mm | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-objective-c++)
+$(eval $(call OBJECT_RULE_template,%.c.i,compile-and-assemble-c-or-c++))
+$(eval $(call OBJECT_RULE_template,%.m.i,compile-and-assemble-objective-c-or-objective-c++))
+$(eval $(call OBJECT_RULE_template,%.cc.i,compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.cp.i,compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.cxx.i,compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.cpp.i,compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.CPP.i,compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.c++.i,compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.C.i,compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.mm.i,compile-and-assemble-objective-c++))
+$(eval $(call OBJECT_RULE_template,%.c,preprocess-compile-and-assemble-c-or-c++))
+$(eval $(call OBJECT_RULE_template,%.m,preprocess-compile-and-assemble-objective-c-or-objective-c++))
+$(eval $(call OBJECT_RULE_template,%.cc,preprocess-compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.cp,preprocess-compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.cxx,preprocess-compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.cpp,preprocess-compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.CPP,preprocess-compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.c++,preprocess-compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.C,preprocess-compile-and-assemble-c++))
+$(eval $(call OBJECT_RULE_template,%.mm,preprocess-compile-and-assemble-objective-c++))
 
 # Handle auto-generated input source files with output in the same build directory.
 
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.c.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c-or-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.m.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-objective-c-or-objective-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.cc.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.cp.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.cxx.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.cpp.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.CPP.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.c++.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.C.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.mm.i) | $(DependDirectory) $(BuildDirectory)
-	$(compile-and-assemble-objective-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.c) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c-or-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.m) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-objective-c-or-objective-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.cc) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.cp) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.cxx) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.cpp) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.CPP) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.c++) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.C) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-c++)
-
-$(call GenerateBuildPaths,%$(SharedObjectSuffix) %$(StaticObjectSuffix)): $(call GenerateBuildPaths,%.mm) | $(DependDirectory) $(BuildDirectory)
-	$(preprocess-compile-and-assemble-objective-c++)
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.c.i,compile-and-assemble-c-or-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.m.i,compile-and-assemble-objective-c-or-objective-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.cc.i,compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.cp.i,compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.cxx.i,compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.cpp.i,compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.CPP.i,compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.c++.i,compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.C.i,compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.mm.i,compile-and-assemble-objective-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.c,preprocess-compile-and-assemble-c-or-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.m,preprocess-compile-and-assemble-objective-c-or-objective-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.cc,preprocess-compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.cp,preprocess-compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.cxx,preprocess-compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.cpp,preprocess-compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.CPP,preprocess-compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.c++,preprocess-compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.C,preprocess-compile-and-assemble-c++))
+$(eval $(call AUTOGEN_OBJECT_RULE_template,%.mm,preprocess-compile-and-assemble-objective-c++))
 
 #
 # Explicit targets


### PR DESCRIPTION
This fully addresses and closes #30 by splitting split shared/static object multi-target pattern rules.

GNU Make 4.4 emits a "pattern recipe did not update peer target" warning for any non-grouped multi-target pattern rule whose recipe does not update every target listed in the rule. From the 4.4 _NEWS_:

> **WARNING:** Future backward-incompatibility! In the NEXT release of
> GNU Make, pattern rules will implement the same behavior change
> for multiple targets as explicit grouped targets [...]: if any
> target of the rule is needed by the build, the recipe will be
> invoked if any target of the rule is missing or out of date.
> [...] GNU Make shows a warning if it detects this situation:
> "pattern recipe did not update peer target".

The shared/static object pattern rules in _post/rules.mak_ use the non-grouped multi-target form intentionally, to express a single rule that produces either a static (`.o`) or a shared (`.so/.dylib`) object from a given source. The per-suffix `CCFLAGS`/`CXXFLAGS` overrides above the rules block select PIC vs non-PIC compilation depending on which output `$@` names, and the recipe produces only the one output named.

This is the documented historical semantics of the non-grouped form, but it now triggers the warning across every `ARCHIVE`/`LIBRARY` target in every consuming makefile under make 4.4, and will fail outright when the next release of make promotes the warning to an error per the _NEWS_ entry above.

Split each affected rule into two single-target pattern rules — one for `SharedObjectSuffix`, one for `StaticObjectSuffix` — which restores the original per-output behavior in a form 4.4+ accepts and the next release will not reject. The per-suffix `CCFLAGS`/`CXXFLAGS` overrides above the rules block continue to apply correctly because both template-generated rules preserve the exact target patterns those overrides key on.

To avoid duplicating ~40 rule bodies, the split is expressed via two `define` templates (`OBJECT_RULE_template` and `AUTOGEN_OBJECT_RULE_template`) invoked once per source suffix with `$(eval $(call ...))`. This matches the existing template-driven idiom already used in this file for `ARCHIVE_template`, `LIBRARY_template`, and `PROGRAM_template`.