### PR TITLE
Harden Static Archive Library Creation 

### DIFF
--- a/make/target/tools/apple/clang/tools.mak
+++ b/make/target/tools/apple/clang/tools.mak
@@ -552,8 +552,15 @@ endef
 # Transform a set of objects into an archive library file.
 
 define tool-create-archive-library
-$(Verbose)$(AR) $(ARFLAGS) $(AROutputFlag) $@ $(ARInputFlag) $(filter-out $($(patsubst $(LibraryPrefix)%,%,$(notdir $(basename $@)))_GENERATION),$(?))
-$(Verbose)$(RANLIB) $(RANLIBFLAGS) $@
+$(Verbose)set -e; \
+    tmp="$@.$$$$"; \
+    trap 'rm -f "$$tmp"' EXIT INT TERM HUP; \
+    rm -f "$$tmp"; \
+    if [ -f "$@" ]; then cp -f "$@" "$$tmp"; else :; fi; \
+    $(AR) $(ARFLAGS) $(AROutputFlag) "$$tmp" $(ARInputFlag) \
+        $(filter-out $($(patsubst $(LibraryPrefix)%,%,$(notdir $(basename $@)))_GENERATION),$(?)); \
+    $(RANLIB) $(RANLIBFLAGS) "$$tmp"; \
+    mv -f "$$tmp" "$@"
 endef
 
 # Transform a set of objects into a shared library file.

--- a/make/target/tools/gnu/gcc/tools.mak
+++ b/make/target/tools/gnu/gcc/tools.mak
@@ -587,8 +587,15 @@ endef
 # Transform a set of objects into an archive library file.
 
 define tool-create-archive-library
-$(Verbose)$(AR) $(ARFLAGS) $(AROutputFlag) $@ $(ARInputFlag) $(filter-out $($(patsubst $(LibraryPrefix)%,%,$(notdir $(basename $@)))_GENERATION),$(?))
-$(Verbose)$(RANLIB) $(RANLIBFLAGS) $@
+$(Verbose)set -e; \
+    tmp="$@.$$$$"; \
+    trap 'rm -f "$$tmp"' EXIT INT TERM HUP; \
+    rm -f "$$tmp"; \
+    if [ -f "$@" ]; then cp -f "$@" "$$tmp"; else :; fi; \
+    $(AR) $(ARFLAGS) $(AROutputFlag) "$$tmp" $(ARInputFlag) \
+        $(filter-out $($(patsubst $(LibraryPrefix)%,%,$(notdir $(basename $@)))_GENERATION),$(?)); \
+    $(RANLIB) $(RANLIBFLAGS) "$$tmp"; \
+    mv -f "$$tmp" "$@"
 endef
 
 # Transform a set of objects into a shared library file.
@@ -608,6 +615,7 @@ endef
 define tool-link-image
 $(Verbose)$(LD) $(LDFLAGS) $(LDOutputFlag) $@ $(filter-out $(SCATTER) $(DEPLIBS) $($(notdir $(basename $@))_GENERATION),$^) $(LDStartGroupFlag) $(call GenerateLibraryArguments,$(LDLIBS)) $(LDEndGroupFlag) $(LDScriptFlag)$(SCATTER) $(LDMapFlag)$(MAPFILE) $(call GenerateResolveArguments,$(RESLIBS))
 endef
+
 #
 # Code Coverage
 #


### PR DESCRIPTION
This fully addresses and closes #34 by making archive creation failure-atomic and parallel-safe.
    
The existing `tool-create-archive-library` recipe runs `ar`(1) and `ranlib`(1) directly against `$@`. This has two failure modes:

* If two concurrent recipe invocations target the same archive (which can happen with overlapping dependency declarations across submakes, or simply with `make -j` and a target reachable through multiple paths), they race on the same file and can produce a corrupted archive whose symbol index doesn't match its members, or whose member list is truncated.
* If `ar` or `ranlib` is interrupted -- `SIGINT` from `^C`, `SIGTERM` from a cancelled build, OOM kill, lost ssh session -- `$@` is left partially written. make's `mtime` check still considers it newer than its prerequisites, so the next build does not retry, and downstream linkers fail with confusing errors against the stale partial archive.

Rewrite the recipe to stage through a process-unique temporary file:

* Stage to "$@.<pid>" rather than `$@` directly.
* If `$@` already exists (incremental rebuild where only some objects changed), seed the temp from the current archive so `ar` can update in place rather than recreating from scratch. This preserves the incremental-update semantics the previous recipe relied on.
* Run `ar` and `ranlib` against the temp.
* `mv`(1) the temp to `$@` as the final step. Within a single filesystem this is atomic: concurrent readers see either the old or the new archive, never a half-written state.
* Trap `EXIT`/`INT`/`TERM`/`HUP` to remove the temp on any failure or signal, so interrupted builds don't leave `.<pid>` droppings in the build tree.
* Use `set -e` so that a failed `ar` or `ranlib` aborts the recipe before `mv` runs, leaving the prior `$@` unchanged rather than partially overwritten.