### PR TITLE
Introduce 'BuildHostSpecialized' for Host-only Makefiles

### DIFF
--- a/make/pre.mak
+++ b/make/pre.mak
@@ -26,6 +26,17 @@ include pre/host.mak
 
 include pre/macros.mak
 
+_BuildHostSpecializedDefault    := No
+BuildHostSpecialized            ?= $(_BuildHostSpecializedDefault)
+
+# If BuildHostSpecialized is explicitly satisfying 'IsYes', then
+# specialize the build for the host and source the project-specific
+# specialization header. Otherwise, specialize the build for target
+# products.
+
+ifeq ($(call IsYes,$(BuildHostSpecialized)),Y)
+include host-specialization.mak
+else
 $(call ErrorIfUndefined,BuildProduct)
 
 # Determine all potential project-sourced product makefiles.
@@ -43,6 +54,7 @@ include $(BuildProductMakefile)
 $(call ErrorIfUndefined,BuildConfig)
 
 include configs/$(BuildConfig).mak
+endif # BuildHostSpecialized=Y
 
 # A TargetOS must be defined.
 

--- a/make/pre/tools.mak
+++ b/make/pre/tools.mak
@@ -41,13 +41,15 @@ MakeToolTuple         = $(1)/$(2)/$(3)
 HostToolTuple         = $(call MakeToolTuple,$(HostToolVendor),$(HostToolProduct),$(HostToolVersion))
 TargetToolTuple       = $(call MakeToolTuple,$(TargetToolVendor),$(TargetToolProduct),$(TargetToolVersion))
 
-# Everything from here forward defaults to using Tool*, if it is a
-# variable or function not qualified with "Host" or "Target". Default
-# to the target definitions for the tool tuple values.
-
+ifeq ($(call IsYes,$(BuildHostSpecialized)),Y)
+ToolVendor            = $(HostToolVendor)
+ToolProduct           = $(HostToolProduct)
+ToolVersion           = $(HostToolVersion)
+else
 ToolVendor            = $(TargetToolVendor)
 ToolProduct           = $(TargetToolProduct)
 ToolVersion           = $(TargetToolVersion)
+endif # BuildHostSpecialized=Y
 
 ToolTuple             = $(call MakeToolTuple,$(ToolVendor),$(ToolProduct),$(ToolVersion))
 


### PR DESCRIPTION
This fully closes and addresses #32 by introducing a new `BuildHostSpecialized` Boolean variable.

Nuovations Build (Make) historically requires every build to be expressed under a specific `BuildProduct` and `BuildConfig`. This forces contortions when a makefile's purpose is not to build product artifacts but to build development-host scaffolding -- code generators, schema compilers, packaging tools, and similar utilities that run on the developer's machine to produce inputs to the actual product build. The conventional workaround has been to declare fake `<product>_sim` "products" that exist solely to host these tools, which pollutes the product namespace and obscures the distinction between real product artifacts and build-time scaffolding.

Introduce a `BuildHostSpecialized` Boolean (validated via `IsYes`) that diverts _pre.mak_ away from the `BuildProduct` path and toward an alternate include of _host-specialization.mak_. The _host-specialized.mak_ file is project-supplied and is expected to:

* unexport `CROSS_COMPILE` if it might be present in the environment;
* establish whatever flag and library bindings the host build needs.

The default (`BuildHostSpecialized` unset or `No`) preserves the existing `BuildProduct`-centric behavior bit-for-bit, so this is opt-in and non-disruptive to existing makefiles.

The corresponding update to _pre/tools.mak_ ensures Tool* defaults resolve to the Host* triple when `BuildHostSpecialized'`is asserted, mirroring the _pre.mak_-internal branch.