### PR TITLE
Enable 'csh', 'tcsh', and other POSIX Shells for Check / Test Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,8 +448,8 @@ check-examples-tcsh:
 check-examples-zsh:
 	$(call check-examples-with-shell,zsh,.)
 
-#check: check-examples-bash check-examples-csh check-examples-dash check-examples-fish check-examples-ksh check-examples-sh check-examples-tcsh check-examples-zsh
-check: check-examples-fish check-examples-ksh
+check: check-examples-bash check-examples-csh check-examples-dash check-examples-fish check-examples-ksh check-examples-sh check-examples-tcsh check-examples-zsh
+check: check-examples-csh check-examples-fish check-examples-ksh check-examples-tcsh
 
 distcheck:
 	$(V_MAKE_TARGET)

--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,6 @@ check-examples-zsh:
 	$(call check-examples-with-shell,zsh,.)
 
 check: check-examples-bash check-examples-csh check-examples-dash check-examples-fish check-examples-ksh check-examples-sh check-examples-tcsh check-examples-zsh
-check: check-examples-csh check-examples-fish check-examples-ksh check-examples-tcsh
 
 distcheck:
 	$(V_MAKE_TARGET)


### PR DESCRIPTION
Enable `csh`, `tcsh`, and other POSIX shells for `make check` test target.